### PR TITLE
remove height & width in pagination button

### DIFF
--- a/src/react-ultimate-pagination-material-ui.js
+++ b/src/react-ultimate-pagination-material-ui.js
@@ -12,8 +12,6 @@ import NavigationChevronRight from '@material-ui/icons/ChevronRight';
 const {classes} = jss
   .createStyleSheet({
     button: {
-      height: '36px',
-      width: '36px',
       'min-width': '36px'
     },
     wrapper: {


### PR DESCRIPTION
1. While doing a webpack4 production mode build the height & width causes some minor mis-alignment hence removed the height & width to have browser set it at auto